### PR TITLE
Add apiVersion to the code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var elasticsearch = require('elasticsearch');
 var client = new elasticsearch.Client({
   host: 'localhost:9200',
   log: 'trace',
-  // apiVersion: '7.2', // if you're not using the latest version, uncomment and specify the engine version you are using
+  apiVersion: '7.2', // use the same version of your Elasticsearch instance
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Create a client instance
 var elasticsearch = require('elasticsearch');
 var client = new elasticsearch.Client({
   host: 'localhost:9200',
-  log: 'trace'
+  log: 'trace',
+  // apiVersion: '7.2', // if you're not using the latest version, uncomment and specify the engine version you are using
 });
 ```
 


### PR DESCRIPTION
Let's make the code example explicitly show the `apiVersion` parameter as if it's misconfigured it can lead to difficult issue to understand.