### PR TITLE
Issue #34, Updated src/lib/host.js

### DIFF
--- a/src/lib/host.js
+++ b/src/lib/host.js
@@ -85,7 +85,7 @@ function Host(config, globalConfig) {
     ) {
       config = defaultProto + '//' + config;
     }
-    config = _.pick(url.parse(config, false, true), urlParseFields);
+    config = _.pick(new url.URL(config), urlParseFields);
     // default logic for the port is to use 9200 for the default. When a string is specified though,
     // we will use the default from the protocol of the string.
     if (!config.port) {


### PR DESCRIPTION
Replaced lagacy API 'url.parse' with WHATWG URL API.

Issue: https://github.com/elastic/elasticsearch-js-legacy/issues/34