### PR TITLE
bugfix/16.x adding `type` into master api instead of `_doc`

### DIFF
--- a/src/lib/apis/master.js
+++ b/src/lib/apis/master.js
@@ -1873,7 +1873,7 @@ api['delete'] = ca({
     }
   },
   url: {
-    fmt: '/<%=index%>/_doc/<%=id%>',
+    fmt: '/<%=index%>/<%=type%>/<%=id%>',
     req: {
       index: {
         type: 'string'
@@ -2193,7 +2193,7 @@ api.exists = ca({
     }
   },
   url: {
-    fmt: '/<%=index%>/_doc/<%=id%>',
+    fmt: '/<%=index%>/<%=type%>/<%=id%>',
     req: {
       index: {
         type: 'string'
@@ -2478,7 +2478,7 @@ api.get = ca({
     }
   },
   url: {
-    fmt: '/<%=index%>/_doc/<%=id%>',
+    fmt: '/<%=index%>/<%=type%>/<%=id%>',
     req: {
       index: {
         type: 'string'
@@ -2658,7 +2658,7 @@ api.index = ca({
   },
   urls: [
     {
-      fmt: '/<%=index%>/_doc/<%=id%>',
+      fmt: '/<%=index%>/<%=type%>/<%=id%>',
       req: {
         index: {
           type: 'string'
@@ -2669,7 +2669,7 @@ api.index = ca({
       }
     },
     {
-      fmt: '/<%=index%>/_doc',
+      fmt: '/<%=index%>/<%=type%>',
       req: {
         index: {
           type: 'string'


### PR DESCRIPTION
[[invalid_type_name_exception] Document mapping type name can't start with '_'](https://stackoverflow.com/questions/69628701/elasticsearch-2-3-geo-point-field-throws-error-when-string-passed-as-arguement/69630572)

I solved the problem. The problem was occurring because of the `apiVersion` switching to the proper version fixed the issue. 


TL;DR;
```
import { Client } from 'elasticsearch';
this.client = new Client({
   host: configService.get<string>('ELASTICSEARCH_HOST'),
   apiVersion: '5.6',
});
```
 
I did some research in the package itself and found out that if you did not specify the `apiVersion` it automatically imports master api and master api formats the url like below, which is wrong.

```
  urls: [
    {
      fmt: '/<%=index%>/_doc/<%=id%>',
      req: {
        index: {
          type: 'string'
        },
        id: {
          type: 'string'
        }
      }
    },
    {
      fmt: '/<%=index%>/_doc',
      req: {
        index: {
          type: 'string'
        }
      }
    }
  ]
```
The whole `_doc` issues come from this formatting, it does not care the mapping name. I think this is a bug. Then I checked the other apis and they were like below;
```
  urls: [
    {
      fmt: '/<%=index%>/<%=type%>/<%=id%>',
      req: {
        index: {
          type: 'string'
        },
        id: {
          type: 'string'
        }
      }
    },
    {
      fmt: '/<%=index%>/<%=type%>',
      req: {
        index: {
          type: 'string'
        }
      }
    }
  ]
```
They include the mapping name which was called type. Then I specify the `apiVersion` for the `Client` problem fixed right away.  

