### PR TITLE
[DOCS] Fix broken links to synced flush API

### DIFF
--- a/docs/api_methods.asciidoc
+++ b/docs/api_methods.asciidoc
@@ -3694,7 +3694,7 @@ client.indices.flushSynced([params, [callback]])
 
 // no description
 
-Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-flush.html#synced-flush-api[the elasticsearch docs] for more information pertaining to this method.
+Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-synced-flush-api.html[the elasticsearch docs] for more information pertaining to this method.
 
 // no examples
 
@@ -3717,7 +3717,7 @@ Options:::
 `index`::
 <<api-param-type-string,`String`>>, <<api-param-type-string-array,`String[]`>>, <<api-param-type-boolean,`Boolean`>> -- A comma-separated list of index names; use `_all` or empty string for all indices
 `body`::
-<<api-param-type-object,`Object`>>, <<api-param-type-json,`JSON`>> -- An optional request body, as either JSON or a JSON serializable object. See https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-flush.html#synced-flush-api[the elasticsearch docs] for details about what can be specified here.
+<<api-param-type-object,`Object`>>, <<api-param-type-json,`JSON`>> -- An optional request body, as either JSON or a JSON serializable object. See https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-synced-flush-api.html[the elasticsearch docs] for details about what can be specified here.
 
 link:#[back to top]
 

--- a/docs/api_methods_7_5.asciidoc
+++ b/docs/api_methods_7_5.asciidoc
@@ -3694,7 +3694,7 @@ client.indices.flushSynced([params, [callback]])
 
 // no description
 
-Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-flush.html#synced-flush-api[the elasticsearch docs] for more information pertaining to this method.
+Check the *<<api-conventions>>* and https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-synced-flush-api.html[the elasticsearch docs] for more information pertaining to this method.
 
 // no examples
 
@@ -3717,7 +3717,7 @@ Options:::
 `index`::
 <<api-param-type-string,`String`>>, <<api-param-type-string-array,`String[]`>>, <<api-param-type-boolean,`Boolean`>> -- A comma-separated list of index names; use `_all` or empty string for all indices
 `body`::
-<<api-param-type-object,`Object`>>, <<api-param-type-json,`JSON`>> -- An optional request body, as either JSON or a JSON serializable object. See https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-flush.html#synced-flush-api[the elasticsearch docs] for details about what can be specified here.
+<<api-param-type-object,`Object`>>, <<api-param-type-json,`JSON`>> -- An optional request body, as either JSON or a JSON serializable object. See https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-synced-flush-api.html[the elasticsearch docs] for details about what can be specified here.
 
 link:#[back to top]
 

--- a/src/lib/apis/7_5.js
+++ b/src/lib/apis/7_5.js
@@ -3286,7 +3286,7 @@ api.indices.prototype.flush = ca({
 });
 
 /**
- * Perform a [indices.flushSynced](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-flush.html#synced-flush-api) request
+ * Perform a [indices.flushSynced](https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-synced-flush-api.html) request
  *
  * @param {Object} params - An object with parameters used to carry out this action
  * @param {<<api-param-type-boolean,`Boolean`>>} params.ignoreUnavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)

--- a/src/lib/apis/7_6.js
+++ b/src/lib/apis/7_6.js
@@ -3286,7 +3286,7 @@ api.indices.prototype.flush = ca({
 });
 
 /**
- * Perform a [indices.flushSynced](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-flush.html#synced-flush-api) request
+ * Perform a [indices.flushSynced](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-synced-flush-api.html) request
  *
  * @param {Object} params - An object with parameters used to carry out this action
  * @param {<<api-param-type-boolean,`Boolean`>>} params.ignoreUnavailable - Whether specified concrete indices should be ignored when unavailable (missing or closed)


### PR DESCRIPTION
Fixes some broken links to the 7.5 and 7.6 synced flush API docs:

* https://www.elastic.co/guide/en/elasticsearch/reference/7.5/indices-synced-flush-api.html
* https://www.elastic.co/guide/en/elasticsearch/reference/7.6/indices-synced-flush-api.html

We have to fix these links to publish these docs as part of https://github.com/elastic/docs/pull/2318.